### PR TITLE
Short README.md and fix for dash 2.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# geting-started-with-plottly-dash
+
+See https://towardsdatascience.com/plotly-dashboards-in-python-28a3bb83702c on "This is How I Create Dazzling Dashboards Purely in Python." from the author.

--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 import dash
-import dash_core_components as dcc
-import dash_html_components as html
-from dash_html_components.Label import Label
+from dash import dcc
+from dash import html
+from dash.html import Label
 from pandas.io.formats import style
 import plotly.express as px
 import pandas as pd
@@ -52,7 +52,7 @@ app.layout = html.Div(
         ),
         html.Div(dcc.Graph(id="life-exp-vs-gdp"), className="chart"),
         dcc.Slider(
-            "year-slider",
+            id="year-slider",
             min=df.Year.min(),
             max=df.Year.max(),
             step=None,


### PR DESCRIPTION
In [2]: import dash_html_components as html
<ipython-input-2-0f04ce9ac34e>:1: UserWarning: 
The dash_html_components package is deprecated. Please replace
`import dash_html_components as html` with `from dash import html`
  import dash_html_components as html

In [3]: import dash_core_components as dcc
<ipython-input-3-b0fa951931d8>:1: UserWarning: 
The dash_core_components package is deprecated. Please replace
`import dash_core_components as dcc` with `from dash import dcc`
  import dash_core_components as dcc
